### PR TITLE
added defer for checking if indexPath is out of bounds

### DIFF
--- a/PagingView/PagingView.swift
+++ b/PagingView/PagingView.swift
@@ -407,12 +407,14 @@ public class PagingView: UIScrollView {
         if let indexPath = dataSource?.indexPathOfStartingInPagingView?(self) ?? reloadingIndexPath {
             do {
                 try containsIndexPath(indexPath)
+                defer {
+                    configureIndexPath = indexPath
+                }
             } catch PagingViewError.IndexPathRange(let message) {
-                fatalError(message)
+                print(message)
             } catch {
                 fatalError("IndexPath is out of range")
             }
-            configureIndexPath = indexPath
         } else {
             if let section = forceSections().first {
                 configureIndexPath = NSIndexPath(forItem: 0, inSection: section)


### PR DESCRIPTION
Don't stop if the indexPath doesn't exist or out of bound.
My use case for this if I want to clear out the scrollView I return 0 to numberOfItems in dataSource and tries to reloadData(). It should just clear out the scrollview

Let me know if you have any good solution for this.
