### PR TITLE
force layout right away

### DIFF
--- a/PagingView/PagingView.swift
+++ b/PagingView/PagingView.swift
@@ -179,7 +179,7 @@ public class PagingView: UIScrollView {
         
         needsReload = true
         setNeedsLayout()
-        self.layoutIfNeeded()
+        layoutIfNeeded()
     }
     
     func invalidateLayout() {

--- a/PagingView/PagingView.swift
+++ b/PagingView/PagingView.swift
@@ -179,6 +179,7 @@ public class PagingView: UIScrollView {
         
         needsReload = true
         setNeedsLayout()
+        self.layoutIfNeeded()
     }
     
     func invalidateLayout() {


### PR DESCRIPTION
the thing is when I call reloadData and tries to get the visiblecells it's empty because layoutSubviews hasn't be called yet. so with this it will force layoutSubviews right away. Let me know if this is okay.
